### PR TITLE
DiadocClient fix AcquireCounteragent query params

### DIFF
--- a/src/diadoc/client.py
+++ b/src/diadoc/client.py
@@ -45,10 +45,11 @@ class DiadocClient:
         organizations: list[DiadocOrganization] = self.http.get("GetOrganizationsByInnKpp", params=params)["Organizations"]  # type: ignore
         return DiadocPartner.from_organization_list(organizations)
 
-    def acquire_counteragent(self, diadoc_id: DiadocId, message: str | None = None) -> DiadocTaskId:
+    def acquire_counteragent(self, my_diadoc_id: DiadocId, diadoc_id: DiadocId, message: str | None = None) -> DiadocTaskId:
+        params = {"myOrgId": my_diadoc_id}
         payload = {"OrgId": diadoc_id}
 
         if message:
             payload["MessageToCounteragent"] = message
 
-        return self.http.post("V2/AcquireCounteragent", payload=payload)["TaskId"]  # type: ignore
+        return self.http.post("V2/AcquireCounteragent", params=params, payload=payload)["TaskId"]  # type: ignore

--- a/src/diadoc/tests/client/conftest.py
+++ b/src/diadoc/tests/client/conftest.py
@@ -2,6 +2,7 @@ from functools import partial
 import pytest
 
 from diadoc.client import DiadocClient
+from diadoc.models import DiadocPartner
 
 
 @pytest.fixture
@@ -13,3 +14,15 @@ def get_diadoc_fixture(get_fixture):
 def client(mocker):
     mocker.patch("diadoc.http.DiadocHTTP.token", return_value="TOKEN", new_callable=mocker.PropertyMock)
     return DiadocClient()
+
+
+@pytest.fixture
+def my_organization():
+    return DiadocPartner(
+        name="Пивзавод",
+        inn="771245768212",
+        kpp=None,
+        diadoc_id="75fcac12-ec63-4cdd-9076-87a8a2e6e8ba",
+        is_active=True,
+        is_roaming=False,
+    )

--- a/src/diadoc/tests/client/tests_acquire_counteragent.py
+++ b/src/diadoc/tests/client/tests_acquire_counteragent.py
@@ -1,12 +1,13 @@
 from functools import partial
 import pytest
+import re
 
 
 @pytest.fixture(autouse=True)
 def mock_diadoc_response(httpx_mock):
     return httpx_mock.add_response(
         method="POST",
-        url="https://diadoc-api.kontur.ru/V2/AcquireCounteragent",
+        url=re.compile("https://diadoc-api.kontur.ru/V2/AcquireCounteragent.*"),
         json={
             "TaskId": "5ef95ef4-8ab9-4c1c-b333-6f78c6a43fd2",
         },
@@ -14,9 +15,10 @@ def mock_diadoc_response(httpx_mock):
 
 
 @pytest.fixture
-def acquire_counteragent(client):
+def acquire_counteragent(client, my_organization):
     return partial(
         client.acquire_counteragent,
+        my_diadoc_id=my_organization.diadoc_id,
         diadoc_id="2c9d3a6d-d8b2-46fc-8bce-af99fc68c575",
     )
 
@@ -25,6 +27,13 @@ def test_acquire_counteragent_return_diadoc_task_id(acquire_counteragent):
     got = acquire_counteragent()
 
     assert got == "5ef95ef4-8ab9-4c1c-b333-6f78c6a43fd2"
+
+
+def test_my_org_id_in_query_params(acquire_counteragent, httpx_mock):
+    acquire_counteragent()
+
+    request_query = httpx_mock.get_request().url.query
+    assert b"myOrgId=75fcac12-ec63-4cdd-9076-87a8a2e6e8ba" in request_query
 
 
 def test_payload_in_request_correct(acquire_counteragent, httpx_mock):

--- a/src/diadoc/tests/client/tests_get_counteragents.py
+++ b/src/diadoc/tests/client/tests_get_counteragents.py
@@ -7,18 +7,6 @@ from diadoc.models import PartnershipStatus
 
 
 @pytest.fixture
-def my_organization():
-    return DiadocPartner(
-        name="Пивзавод",
-        inn="771245768212",
-        kpp=None,
-        diadoc_id="75fcac12-ec63-4cdd-9076-87a8a2e6e8ba",
-        is_active=True,
-        is_roaming=False,
-    )
-
-
-@pytest.fixture
 def page_one(get_diadoc_fixture):
     return get_diadoc_fixture("GetCounteragents_page_one.json")
 

--- a/src/tinkoff_to_diadoc/service.py
+++ b/src/tinkoff_to_diadoc/service.py
@@ -69,9 +69,9 @@ class TinkoffToDiadoc:
 
         return to_invite
 
-    def send_invites(self, partners: list[DiadocPartner]) -> None:
+    def send_invites(self, my_company: DiadocPartner, partners: list[DiadocPartner]) -> None:
         for partner in partners:
-            self.diadoc.acquire_counteragent(diadoc_id=partner.diadoc_id, message=self.message_to_acquire)
+            self.diadoc.acquire_counteragent(my_company.diadoc_id, partner.diadoc_id, self.message_to_acquire)
 
     def act(self) -> None:
         counteragents = self.get_counteragents(self.my_company)
@@ -82,4 +82,4 @@ class TinkoffToDiadoc:
         partners_from_payers = self.get_distinct_partners_from_payers(payers_not_in_partners)
         partners_to_invite = self.exclude_partners_not_needed_to_invite(partners_from_payers, counteragents)
 
-        self.send_invites(partners_to_invite)
+        self.send_invites(self.my_company, partners_to_invite)

--- a/src/tinkoff_to_diadoc/tests/tests_tinkoff_to_diadoc_send_invites.py
+++ b/src/tinkoff_to_diadoc/tests/tests_tinkoff_to_diadoc_send_invites.py
@@ -1,5 +1,7 @@
 import pytest
 
+from diadoc.models import DiadocPartner
+
 
 @pytest.fixture(autouse=True)
 def _set_message_to_counteragents(monkeypatch):
@@ -12,17 +14,29 @@ def mock_acquire_counteragent(mocker):
 
 
 @pytest.fixture
+def my_company():
+    return DiadocPartner(
+        name="Пивзавод",
+        inn="771245768212",
+        kpp=None,
+        diadoc_id="75fcac12-ec63-4cdd-9076-87a8a2e6e8ba",
+        is_active=True,
+        is_roaming=False,
+    )
+
+
+@pytest.fixture
 def send_invites(tinkoff_to_diadoc):
-    return lambda *partners: tinkoff_to_diadoc.send_invites(partners)
+    return lambda my_company, partners: tinkoff_to_diadoc.send_invites(my_company, partners)
 
 
-def test_call_acquire_counteragent_for_every_partner(send_invites, partner, ya_partner, mock_acquire_counteragent, mocker):
-    send_invites(partner, ya_partner)
+def test_call_acquire_counteragent_for_every_partner(send_invites, my_company, partner, ya_partner, mock_acquire_counteragent, mocker):
+    send_invites(my_company, [partner, ya_partner])
 
     mock_acquire_counteragent.assert_has_calls(
         calls=[
-            mocker.call(diadoc_id=partner.diadoc_id, message="Давай запартнеримся в Диадок!"),
-            mocker.call(diadoc_id=ya_partner.diadoc_id, message="Давай запартнеримся в Диадок!"),
+            mocker.call(my_company.diadoc_id, partner.diadoc_id, "Давай запартнеримся в Диадок!"),
+            mocker.call(my_company.diadoc_id, ya_partner.diadoc_id, "Давай запартнеримся в Диадок!"),
         ],
         any_order=True,
     )


### PR DESCRIPTION
Пропустил обязательный query параметр в методе диадок `AcquireCounteragent`.
Добавил.