### PR TITLE
Diadoc `AcquireCounteragent`: do not raise on errors but capture exception

### DIFF
--- a/src/diadoc/client.py
+++ b/src/diadoc/client.py
@@ -56,5 +56,5 @@ class DiadocClient:
 
         try:
             self.http.post("V2/AcquireCounteragent", params=params, payload=payload)
-        except DiadocHTTPException as exception:
+        except DiadocHTTPException as exception:  # do not fail on HTTP errors, just send them to sentry
             capture_exception(exception)

--- a/src/diadoc/tests/client/tests_acquire_counteragent.py
+++ b/src/diadoc/tests/client/tests_acquire_counteragent.py
@@ -1,9 +1,10 @@
+from contextlib import nullcontext as does_not_raise
 from functools import partial
 import pytest
 import re
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_diadoc_response(httpx_mock):
     return httpx_mock.add_response(
         method="POST",
@@ -15,6 +16,11 @@ def mock_diadoc_response(httpx_mock):
 
 
 @pytest.fixture
+def mock_sentry_capture(mocker):
+    return mocker.patch("diadoc.client.capture_exception")
+
+
+@pytest.fixture
 def acquire_counteragent(client, my_organization):
     return partial(
         client.acquire_counteragent,
@@ -23,20 +29,14 @@ def acquire_counteragent(client, my_organization):
     )
 
 
-def test_acquire_counteragent_return_diadoc_task_id(acquire_counteragent):
-    got = acquire_counteragent()
-
-    assert got == "5ef95ef4-8ab9-4c1c-b333-6f78c6a43fd2"
-
-
-def test_my_org_id_in_query_params(acquire_counteragent, httpx_mock):
+def test_my_org_id_in_query_params(acquire_counteragent, httpx_mock, mock_diadoc_response):
     acquire_counteragent()
 
     request_query = httpx_mock.get_request().url.query
     assert b"myOrgId=75fcac12-ec63-4cdd-9076-87a8a2e6e8ba" in request_query
 
 
-def test_payload_in_request_correct(acquire_counteragent, httpx_mock):
+def test_payload_in_request_correct(acquire_counteragent, httpx_mock, mock_diadoc_response):
     acquire_counteragent(message="Hello everyone!")
 
     request_content = httpx_mock.get_request().content
@@ -45,10 +45,19 @@ def test_payload_in_request_correct(acquire_counteragent, httpx_mock):
 
 @pytest.mark.parametrize(
     "message",
-    [None, "", "Yo!"],
+    [None, ""],
 )
-def test_do_not_include_message_in_payload_if_empty(acquire_counteragent, httpx_mock, message):
+def test_do_not_include_message_in_payload_if_empty(acquire_counteragent, httpx_mock, message, mock_diadoc_response):
     acquire_counteragent(message=message)
 
     request_content = httpx_mock.get_request().content
-    assert b"message" not in request_content
+    assert b"MessageToCounteragent" not in request_content
+
+
+def test_do_not_raise_on_errors_and_capture_exception_to_sentry(acquire_counteragent, httpx_mock, mock_sentry_capture):
+    httpx_mock.add_response(status_code=409, text="Setting is required for document exchange. Apply for roaming on www.diadoc.ru/roaming")
+
+    with does_not_raise():
+        acquire_counteragent()
+
+    mock_sentry_capture.assert_called_once()

--- a/src/diadoc/types.py
+++ b/src/diadoc/types.py
@@ -1,7 +1,6 @@
 from typing import Literal, TypeAlias, TypedDict
 
 DiadocId: TypeAlias = str
-DiadocTaskId: TypeAlias = str
 
 
 class DiadocOrganization(TypedDict):


### PR DESCRIPTION
Diadoc `AcquireCounteragent` — не падать в случае ошибки, но отправлять данные в sentry.

Появился клиент, которому не можем отправить автоматически приглашение в Диадок.
Что с такими делать (и можем ли до попытки отправить приглашение) пока не знаю.

Это мелкий фикс, чтоб приложение не падало (и не спамило ошибки в sentry), но сообщало, что что-то идёт не так.