### PR TITLE
Tinkoff get_payers: skip operations without payer

### DIFF
--- a/src/tinkoff_business/client.py
+++ b/src/tinkoff_business/client.py
@@ -48,5 +48,5 @@ class TinkoffBusinessClient:
                 kpp=operation["payer"].get("kpp"),
             )
             for operation in statement["operations"]
-            if "inn" in operation["payer"]
+            if "payer" in operation and "inn" in operation["payer"]
         ]

--- a/src/tinkoff_business/tests/client/tests_get_payers_with_non_empty_inn.py
+++ b/src/tinkoff_business/tests/client/tests_get_payers_with_non_empty_inn.py
@@ -17,6 +17,12 @@ def mock_tinkoff_response(httpx_mock, bank_statement_json):
 
 
 @pytest.fixture
+def bank_statement_without_payer(bank_statement_json):
+    bank_statement_json["operations"][0].pop("payer")
+    return bank_statement_json
+
+
+@pytest.fixture
 def bank_statement_payer_empty_inn(bank_statement_json):
     bank_statement_json["operations"][0]["payer"].pop("inn")
     return bank_statement_json
@@ -53,6 +59,14 @@ def test_get_payers_with_non_empty_inn_return_legal_entiry(client, mock_tinkoff_
     got = client.get_payers_with_non_empty_inn("100500")
 
     assert got == [LegalEntity(name="ИП Котиков Александр Михайлович", inn="17499237465", kpp=None)]
+
+
+def test_skip_operations_without_payer(client, mock_tinkoff_response, bank_statement_without_payer):
+    mock_tinkoff_response(json=bank_statement_without_payer)
+
+    got = client.get_payers_with_non_empty_inn("100500")
+
+    assert got == []
 
 
 def test_do_not_include_payers_with_empty_inn(client, mock_tinkoff_response, bank_statement_payer_empty_inn):

--- a/src/tinkoff_business/types.py
+++ b/src/tinkoff_business/types.py
@@ -21,7 +21,7 @@ class TinkoffPayer(TypedDict):
 
 class TinkoffOperation(TypedDict):
     operationId: str
-    payer: TinkoffPayer
+    payer: NotRequired[TinkoffPayer]
 
 
 class TinkoffStatement(TypedDict):


### PR DESCRIPTION
Обработка операций тинькоф, в которых не указан плательщик.
Такие бывают.